### PR TITLE
Fix for Android 10 location permission

### DIFF
--- a/CN1Bluetooth/codenameone_library_appended.properties
+++ b/CN1Bluetooth/codenameone_library_appended.properties
@@ -3,7 +3,7 @@
 #is an appended type property.
 #
 #Wed Jan 09 17:59:31 IST 2013
-codename1.arg.android.xpermissions=<uses-permission android:name="android.permission.BLUETOOTH"/><uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/><uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+codename1.arg.android.xpermissions=<uses-permission android:name="android.permission.BLUETOOTH"/><uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/><uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 codename1.arg.ios.pods=,Cordova ~> 6.1
 codename1.arg.ios.pods.platform=,11.0
 codename1.arg.ios.add_libs=;CoreBluetooth.framework;

--- a/CN1Bluetooth/native/android/com/codename1/bluetoothle/BluetoothLePlugin.java
+++ b/CN1Bluetooth/native/android/com/codename1/bluetoothle/BluetoothLePlugin.java
@@ -61,6 +61,7 @@ public class BluetoothLePlugin extends CordovaPlugin {
     private final int REQUEST_BT_ENABLE = 59627; /*Random integer*/
 
     private final int REQUEST_ACCESS_COARSE_LOCATION = 59628;
+    private final int REQUEST_ACCESS_FINE_LOCATION = 59630;
     private final int REQUEST_LOCATION_SOURCE_SETTINGS = 59629;
     private BluetoothAdapter bluetoothAdapter;
     private boolean isReceiverRegistered = false;
@@ -855,7 +856,7 @@ public class BluetoothLePlugin extends CordovaPlugin {
     public void hasPermissionAction(CallbackContext callbackContext) {
         JSONObject returnObj = new JSONObject();
 
-        addProperty(returnObj, "hasPermission", cordova.hasPermission(Manifest.permission.ACCESS_COARSE_LOCATION));
+        addProperty(returnObj, "hasPermission", cordova.hasPermission(Manifest.permission.ACCESS_FINE_LOCATION));
 
         callbackContext.success(returnObj);
     }
@@ -870,7 +871,7 @@ public class BluetoothLePlugin extends CordovaPlugin {
         }
 
         permissionsCallback = callbackContext;
-        cordova.requestPermission(this, REQUEST_ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION);
+        cordova.requestPermission(this, REQUEST_ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION);
     }
 
     public void onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) throws JSONException {
@@ -881,7 +882,7 @@ public class BluetoothLePlugin extends CordovaPlugin {
         //Just call hasPermission again to verify
         JSONObject returnObj = new JSONObject();
 
-        addProperty(returnObj, "requestPermission", cordova.hasPermission(Manifest.permission.ACCESS_COARSE_LOCATION));
+        addProperty(returnObj, "requestPermission", cordova.hasPermission(Manifest.permission.ACCESS_FINE_LOCATION));
 
         permissionsCallback.success(returnObj);
     }


### PR DESCRIPTION
Android 10 requires fine location permission and access for Bluetooth LE. Changed ACCESS_COARSE_LOCATION to ACCESS_FINE_LOCATION in two files to make this change and to automatically update the Android permissions build hints.